### PR TITLE
Fix auth header not being sent in JsonRpc

### DIFF
--- a/lms-material/src/main/java/com/craigd/lmsmaterial/app/JsonRpc.java
+++ b/lms-material/src/main/java/com/craigd/lmsmaterial/app/JsonRpc.java
@@ -47,11 +47,8 @@ public class JsonRpc {
                 return  super.getHeaders();
             }
 
-            Map<String, String> headers = super.getHeaders();
-            if (null==headers) {
-                headers = new HashMap<>();
-                headers.put("Authorization", "Basic " + B64Code.encode(user + ":" + pass));
-            }
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Authorization", "Basic " + B64Code.encode(user + ":" + pass));
             return headers;
         }
     };


### PR DESCRIPTION
Since `Request.getHeaders` always returns `Collections.emptyMap()`, `headers` would never be null and so the auth header would never be added. This would cause, for example, the notification media controls to not work, as the request would cause a 401 response.