### PR TITLE
Use MIXED_CONTENT_COMPATIBILITY_MODE for the LMS WebView

### DIFF
--- a/lms-material/src/main/java/com/craigd/lmsmaterial/app/MainActivity.java
+++ b/lms-material/src/main/java/com/craigd/lmsmaterial/app/MainActivity.java
@@ -597,7 +597,11 @@ public class MainActivity extends AppCompatActivity {
         webSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
         webSettings.setLoadWithOverviewMode(true);
         webSettings.setUseWideViewPort(false);
-        webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        // COMPATIBILITY_MODE keeps cover-art and similar passive sub-resources
+        // working when the LMS server is reachable over https while still
+        // blocking active mixed content like scripts. ALWAYS_ALLOW is the
+        // strictly less-safe option from the WebSettings javadoc.
+        webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         webSettings.setTextZoom(100);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             webSettings.setAlgorithmicDarkeningAllowed(false);


### PR DESCRIPTION
Closes #77.

`MainActivity` configures the WebView with:

```java
webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
```

`MIXED_CONTENT_ALWAYS_ALLOW` is documented as the strictly less safe choice in the `WebSettings` javadoc. It lets an https page load every kind of http sub-resource, including remote scripts.

### Why `COMPATIBILITY_MODE` rather than `NEVER_ALLOW`

`NEVER_ALLOW` would break setups where the user runs LMS over https but the per-track stream or cover-art URL is plain http, which is fairly common since LMS often proxies third-party streams that are not https.

`COMPATIBILITY_MODE` keeps passive sub-resources like images and audio loading on an https page while blocking active mixed content like remote scripts. This matches how Chrome handles mixed content in the address bar and is the right default for a music controller.

### Scope

The change is a single line in `MainActivity.configureWebView` (around line 600), plus an inline comment recording the trade-off. The http-only LMS path (the default `Uri.parse("http://...")` builder elsewhere in the same activity) is unaffected, because mixed-content checks only apply when the main frame is itself https.