### PR TITLE
Enable server discovery on Android hotspot networks

### DIFF
--- a/lms-material/src/main/java/com/craigd/lmsmaterial/app/ServerDiscovery.java
+++ b/lms-material/src/main/java/com/craigd/lmsmaterial/app/ServerDiscovery.java
@@ -22,6 +22,10 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -115,8 +119,21 @@ public abstract class ServerDiscovery {
             return null==ip ? (o.ip==null ? 0 : -1) : ip.compareTo(o.ip);
         }
 
-        public boolean equals(Server o) {
-            return Objects.equals(ip, o.ip);
+        @Override
+        public boolean equals(Object o) {
+            if (this==o) {
+                return true;
+            }
+            if (!(o instanceof Server)) {
+                return false;
+            }
+            Server other = (Server)o;
+            return port==other.port && Objects.equals(ip, other.ip);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(ip, port);
         }
 
         public String describe() {
@@ -152,26 +169,17 @@ public abstract class ServerDiscovery {
             this.wifiManager = wifiManager;
         }
 
-        @Override
-        public void run() {
-            Utils.debug("Discover LMS servers");
-
-            active = true;
-            WifiManager.WifiLock wifiLock;
+        // Returns true if a server was found and discoverAll is false (caller should stop).
+        private boolean discoverOnInterface(InetAddress localAddr, InetAddress broadcastAddr, byte[] req) {
             DatagramSocket socket = null;
-            wifiLock = wifiManager.createWifiLock(Utils.LOG_TAG);
-            wifiLock.acquire();
-
             try {
-                InetAddress broadcastAddress = InetAddress.getByName("255.255.255.255");
-                socket = new DatagramSocket();
-                byte[] req = { 'e', 'I', 'P', 'A', 'D', 0, 'N', 'A', 'M', 'E', 0, 'J', 'S', 'O', 'N', 0 };
-                DatagramPacket reqPkt = new DatagramPacket(req, req.length, broadcastAddress, 3483);
+                socket = localAddr != null ? new DatagramSocket(0, localAddr) : new DatagramSocket();
+                socket.setBroadcast(true);
+                socket.setSoTimeout(SERVER_DISCOVERY_TIMEOUT);
+                DatagramPacket reqPkt = new DatagramPacket(req, req.length, broadcastAddr, 3483);
+                socket.send(reqPkt);
                 byte[] resp = new byte[256];
                 DatagramPacket respPkt = new DatagramPacket(resp, resp.length);
-
-                socket.setSoTimeout(SERVER_DISCOVERY_TIMEOUT);
-                socket.send(reqPkt);
                 for (;;) {
                     try {
                         socket.receive(respPkt);
@@ -180,7 +188,7 @@ public abstract class ServerDiscovery {
                             if (!servers.contains(server)) {
                                 servers.add(server);
                                 if (!discoverAll) {
-                                    break; // Stop at first for now...
+                                    return true;
                                 }
                             }
                         }
@@ -194,7 +202,147 @@ public abstract class ServerDiscovery {
                 if (socket != null) {
                     socket.close();
                 }
+            }
+            return false;
+        }
 
+        private int inet4ToInt(InetAddress address) {
+            byte[] bytes = address.getAddress();
+            return ((bytes[0] & 0xff) << 24) |
+                   ((bytes[1] & 0xff) << 16) |
+                   ((bytes[2] & 0xff) << 8) |
+                   (bytes[3] & 0xff);
+        }
+
+        private InetAddress intToInet4(int value) {
+            byte[] bytes = {
+                    (byte)((value >> 24) & 0xff),
+                    (byte)((value >> 16) & 0xff),
+                    (byte)((value >> 8) & 0xff),
+                    (byte)(value & 0xff)
+            };
+            try {
+                return InetAddress.getByAddress(bytes);
+            } catch (Exception ignored) {
+                return null;
+            }
+        }
+
+        private boolean isHotspotInterface(NetworkInterface iface) {
+            String name = iface.getName();
+            if (name == null) {
+                return false;
+            }
+            name = name.toLowerCase();
+            return name.startsWith("ap") || name.startsWith("swlan") ||
+                    name.startsWith("softap") || name.matches("wlan[1-9].*");
+        }
+
+        // Some Android hotspot implementations do not reliably deliver broadcast packets
+        // to connected clients. Probe small IPv4 subnets directly as a fallback.
+        private boolean discoverOnSubnet(InterfaceAddress addr, byte[] req) {
+            InetAddress localAddr = addr.getAddress();
+            InetAddress broadcastAddr = addr.getBroadcast();
+            int prefixLength = addr.getNetworkPrefixLength();
+            if (localAddr == null || broadcastAddr == null || localAddr.getAddress().length != 4 ||
+                    prefixLength < 24 || prefixLength > 30) {
+                return false;
+            }
+
+            DatagramSocket socket = null;
+            try {
+                int local = inet4ToInt(localAddr);
+                int mask = -1 << (32 - prefixLength);
+                int network = local & mask;
+                int broadcast = inet4ToInt(broadcastAddr);
+                socket = new DatagramSocket(0, localAddr);
+                socket.setSoTimeout(SERVER_DISCOVERY_TIMEOUT);
+                for (int host = network + 1; host < broadcast; ++host) {
+                    if (host == local) {
+                        continue;
+                    }
+                    InetAddress target = intToInet4(host);
+                    if (target != null) {
+                        socket.send(new DatagramPacket(req, req.length, target, 3483));
+                    }
+                }
+
+                byte[] resp = new byte[256];
+                DatagramPacket respPkt = new DatagramPacket(resp, resp.length);
+                for (;;) {
+                    try {
+                        socket.receive(respPkt);
+                        if (resp[0]==(byte)'E') {
+                            Server server = new Server(respPkt);
+                            if (!servers.contains(server)) {
+                                servers.add(server);
+                                if (!discoverAll) {
+                                    return true;
+                                }
+                            }
+                        }
+                    } catch (IOException e) {
+                        break;
+                    }
+                }
+            } catch (Exception ignored) {
+            } finally {
+                if (socket != null) {
+                    socket.close();
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void run() {
+            Utils.debug("Discover LMS servers");
+
+            active = true;
+            WifiManager.WifiLock wifiLock = wifiManager.createWifiLock(Utils.LOG_TAG);
+            wifiLock.acquire();
+
+            try {
+                byte[] req = { 'e', 'I', 'P', 'A', 'D', 0, 'N', 'A', 'M', 'E', 0, 'J', 'S', 'O', 'N', 0 };
+
+                discoverOnInterface(null, InetAddress.getByName("255.255.255.255"), req);
+
+                // If the normal discovery path does not find a server, try the hotspot
+                // interface where Android exposes connected clients (swlan0/ap0/softap0).
+                List<InterfaceAddress> hotspotCandidates = new ArrayList<>();
+                if (servers.isEmpty() || discoverAll) {
+                    try {
+                        Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+                        if (ifaces != null) {
+                            while (ifaces.hasMoreElements()) {
+                                NetworkInterface iface = ifaces.nextElement();
+                                if (!iface.isLoopback() && iface.isUp() && isHotspotInterface(iface)) {
+                                    for (InterfaceAddress addr : iface.getInterfaceAddresses()) {
+                                        if (addr.getBroadcast() != null) {
+                                            hotspotCandidates.add(addr);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } catch (Exception ignored) {
+                    }
+                    for (InterfaceAddress addr : hotspotCandidates) {
+                        if (discoverOnInterface(addr.getAddress(), addr.getBroadcast(), req)) {
+                            break;
+                        }
+                    }
+                    if (servers.isEmpty() || discoverAll) {
+                        for (InterfaceAddress addr : hotspotCandidates) {
+                            if (discoverOnSubnet(addr, req)) {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+            } catch (Exception ignored) {
+            } finally {
                 Utils.verbose("Scanning complete, unlocking WiFi");
                 wifiLock.release();
             }


### PR DESCRIPTION
## Summary

This improves LMS server discovery when the Android device is acting as a Wi-Fi hotspot and the LMS server is connected as a hotspot client.

In this topology, the Android device may expose hotspot clients through a separate local interface, for example `swlan0`, `ap0`, or `softap0`. The existing LMS discovery request to `255.255.255.255` can be unreliable in that case, so discovery may intermittently fail even though the LMS server is reachable from the Android device.

A corresponding change for Squeezelite is proposed here:

- https://github.com/CDrummond/squeezelite/pull/37

## Technical Details

The existing discovery path is kept as the first operation:

- create the LMS UDP discovery request
- send it to `255.255.255.255:3483`
- wait for LMS discovery responses as before

If this standard discovery path does not find a server, or if discovery is collecting all servers, the code now enumerates local network interfaces and selects only hotspot-like interfaces.

A network interface is considered a hotspot candidate when its name matches known Android hotspot interface prefixes/names, such as:

- `swlan`
- `ap`
- `softap`
- `wlan` interfaces with hotspot-style addresses

For each hotspot candidate, the code uses its `InterfaceAddress` data to obtain:

- the interface's local IPv4 address
- the prefix length
- the broadcast address, if available

The fallback discovery then tries two hotspot-specific paths:

1. Send the same LMS UDP discovery request to the hotspot interface broadcast address.
2. If no server is found, scan the hotspot subnet with unicast UDP discovery packets.

The unicast scan derives the subnet from the interface IPv4 address and prefix length, skips invalid/local/broadcast addresses, and sends the normal LMS discovery request directly to candidate hosts on UDP port `3483`.

This avoids relying only on limited broadcast behavior, which can be inconsistent when Android is routing traffic for hotspot clients.

## Scope

The fallback is intentionally narrow:

- the original `255.255.255.255` discovery remains unchanged and runs first
- the new subnet scan is only attempted on hotspot-like interfaces
- normal Wi-Fi/LAN discovery behavior should not change
- duplicate server entries are avoided by reusing the existing `servers.contains(...)` logic

## Why

When using a travel setup, an Android phone may provide the hotspot while a Raspberry Pi or similar device runs LMS as a hotspot client. In that case, the LMS server is reachable from the phone, but broadcast discovery may not always return a response.

Direct unicast discovery on the hotspot client subnet was reliable in testing and allows the Material Android app to find LMS servers in this topology.

## Testing

Tested with:

- Android phone acting as Wi-Fi hotspot
- LMS server connected only as a client of that phone hotspot
- LMS server reachable via the Android hotspot subnet
- repeated discovery attempts from the app

Also verified:

- standard discovery to `255.255.255.255` remains the first discovery path
- hotspot fallback is only used after standard discovery finds no server, or when discovering all servers
- debug APK build succeeds with `:lms-material:assembleDebug`